### PR TITLE
Log book edits

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: WildExtras
 main: org.hopto.thewild.WildExtras.WildExtras
-version: 1.0.0
+version: 1.1.0
 depends: [CraftIRC, Essentials, dynmap, Stats, GroupManager]
 commands:
    wedebug:

--- a/src/main/java/org/hopto/thewild/WildExtras/WEListeners.java
+++ b/src/main/java/org/hopto/thewild/WildExtras/WEListeners.java
@@ -31,6 +31,7 @@ import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.hanging.HangingBreakByEntityEvent;
 import org.bukkit.event.hanging.HangingPlaceEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.player.PlayerEditBookEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerPickupItemEvent;
@@ -39,8 +40,10 @@ import org.bukkit.Location;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.HorseInventory;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.meta.BookMeta;
 import org.bukkit.Material;
 import org.bukkit.metadata.FixedMetadataValue;
+import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.PluginManager;
@@ -842,6 +845,24 @@ public void checkVehicleDismount(VehicleExitEvent e) {
     }
 
 }
+
+// Log edited books so we can see who left offensive stuff.
+@EventHandler
+public void logEditedBook(PlayerEditBookEvent e) {
+    Player player = e.getPlayer();
+    BookMeta meta = e.getNewBookMeta();
+    plugin.getLogger().info(
+        "Player " + player.getName() + " is editing a book titled '"
+        + meta.getTitle() + "', page contents follow"
+    );
+    for (String page: meta.getPages()) {
+        plugin.getLogger().info(page);
+    }
+}
+
+//
+// PlayerEditBookEvent(Player who, int slot, BookMeta previousBookMeta, BookMeta
+// newBookMeta, boolean isSigning) 
 
 
 

--- a/src/main/java/org/hopto/thewild/WildExtras/WEListeners.java
+++ b/src/main/java/org/hopto/thewild/WildExtras/WEListeners.java
@@ -858,6 +858,12 @@ public void logEditedBook(PlayerEditBookEvent e) {
     for (String page: meta.getPages()) {
         plugin.getLogger().info(page);
     }
+
+    // Record them as the author;  Normally this is only done when the book is
+    // signed, but we don't want people to be able to use an unsigned book &
+    // quill to leave anonymous abusive messages in people's hoppers, etc.
+    meta.setAuthor(player.getName());
+    e.setNewBookMeta(meta);
 }
 
 //


### PR DESCRIPTION
Log book edits, and also set the book's author (normally, a book & quill has no author set until it's signed, which means we can't see who left an offensive message, and that's shit).