### PR TITLE
Name colors via permission nodes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 <modelVersion>4.0.0</modelVersion>
   <groupId>org.bukkit</groupId>
    <name>WildExtras</name>
-   <version>1.1.0</version>
+   <version>1.1.1</version>
      <artifactId>WildExtras</artifactId>
   <packaging>jar</packaging>
   <url>http://the-wild.hopto.org</url>

--- a/src/main/java/org/hopto/thewild/WildExtras/WEListeners.java
+++ b/src/main/java/org/hopto/thewild/WildExtras/WEListeners.java
@@ -531,14 +531,16 @@ public class WEListeners implements Listener {
         // hook in to permissions plugin to know about groups, I've just given
         // each group a group.<name> permission node we can check for.
         // Because of inheritance, check in descending order.
-        if (player.hasPermission("group.admin")) {
-            color = ChatColor.GREEN;
-        } else if (player.hasPermission("group.mod")) {
-            color = ChatColor.GOLD;
-        } else if (player.hasPermission("group.playermod")) {
-            color = ChatColor.GRAY;
-        } else if (player.hasPermission("group.regular")) {
-            color = ChatColor.YELLOW;
+        if (color != null) {
+            if (player.hasPermission("group.admin")) {
+                color = ChatColor.GREEN;
+            } else if (player.hasPermission("group.mod")) {
+                color = ChatColor.GOLD;
+            } else if (player.hasPermission("group.playermod")) {
+                color = ChatColor.GRAY;
+            } else if (player.hasPermission("group.regular")) {
+                color = ChatColor.YELLOW;
+            }
         }
 
         if (color != null) {

--- a/src/main/java/org/hopto/thewild/WildExtras/WEListeners.java
+++ b/src/main/java/org/hopto/thewild/WildExtras/WEListeners.java
@@ -524,21 +524,22 @@ public class WEListeners implements Listener {
             color = ChatColor.LIGHT_PURPLE;
         } else if (isProtected(player)) {
             color = ChatColor.DARK_RED;
-        } else {
+        }
+
+        // If we didn't pick a colour above to signify PvP protection/newbness
+        // then color based on their group, if they have one; rather than
+        // hook in to permissions plugin to know about groups, I've just given
+        // each group a group.<name> permission node we can check for.
+        // Because of inheritance, check in descending order.
+        if (player.hasPermission("group.admin")) {
+            color = ChatColor.GREEN;
+        } else if (player.hasPermission("group.mod")) {
+            color = ChatColor.GOLD;
+        } else if (player.hasPermission("group.playermod")) {
+            color = ChatColor.GRAY;
+        } else if (player.hasPermission("group.regular")) {
             color = ChatColor.YELLOW;
         }
-        /*
-         * reinstate if I get GroupManager to work as a dep again? or just add a
-         * permission to each group named after it, so you could just say
-         * player.hasPermission('Admin') ? } else if (setupGroupManagerAPI()) { String
-         * group = getPlayerGroup(player); debugmsg( "colorNick() got group " + group +
-         * " for " + player.getName() );
-         * 
-         * if (group.equals("Mod")) { color = ChatColor.GOLD; } else if
-         * (group.equals("PlayerMod")) { color = ChatColor.GRAY; } else if
-         * (group.equals("Admin")) { color = ChatColor.GREEN; } else { color =
-         * ChatColor.YELLOW; }
-         */
 
         if (color != null) {
             player.setPlayerListName(color + player.getName() + ChatColor.RESET);


### PR DESCRIPTION
Reinstate name colouring.

No real need to go to the effort of hooking in to a permissions plugin to find out what group they are a member of; instead, I've just given each group a group.<name> permission node we can check for with standard hasPermission() 